### PR TITLE
Add Human Delta wind enrichment to drift forecasting pipeline

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ scikit-learn>=1.3.0
 matplotlib>=3.7.0
 folium>=0.14.0
 requests>=2.31.0
+httpx>=0.27.0
 python-dotenv>=1.0.0
 tqdm>=4.65.0
 opendrift>=1.14.0

--- a/src/forecast/drift.py
+++ b/src/forecast/drift.py
@@ -30,6 +30,7 @@ from pathlib import Path
 import numpy as np
 
 from src.forecast.oscar_concat import concat_oscar
+from src.forecast.wind_enrichment import HumanDeltaClient
 from src.forecast.seed import (
     DEFAULT_DEBRIS_CLASSES,
     Seed,
@@ -435,7 +436,31 @@ def main() -> None:
     parser.add_argument("--wind-drift-factor", type=float, default=0.0,
                         help="Per-particle leeway as fraction of wind speed "
                              "(0.02-0.04 typical for floating debris)")
+    parser.add_argument("--raw-weather-log", type=str, default=None,
+                        help="Unstructured text notes about weather/wind conditions "
+                             "to be structured by Human Delta")
     args = parser.parse_args()
+
+    if args.raw_weather_log:
+        client = HumanDeltaClient()
+        wind_params = client.structure_wind_data(args.raw_weather_log)
+        if wind_params["confidence_score"] > 0.7:
+            args.wind_speed = wind_params["wind_speed_ms"]
+            args.wind_dir = wind_params["wind_dir_deg"]
+            args.wind_drift_factor = wind_params["wind_drift_factor"]
+            print(
+                f"[drift] Human Delta enrichment applied  "
+                f"(confidence={wind_params['confidence_score']:.2f}): "
+                f"wind_speed={args.wind_speed:.2f} m/s  "
+                f"wind_dir={args.wind_dir:.1f} deg  "
+                f"wind_drift_factor={args.wind_drift_factor:.3f}"
+            )
+        else:
+            print(
+                f"[drift] Human Delta confidence too low "
+                f"({wind_params['confidence_score']:.2f} <= 0.70); "
+                "keeping manual wind parameters."
+            )
 
     run_drift(
         predictions_path=args.predictions,

--- a/src/forecast/wind_enrichment.py
+++ b/src/forecast/wind_enrichment.py
@@ -1,0 +1,86 @@
+"""Human Delta API client for structuring raw weather logs into wind parameters.
+
+Converts unformatted text (e.g. field notes, weather station logs) into
+validated physics parameters consumed by the OpenDrift drift simulator.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+from pydantic import BaseModel, Field, ValidationError
+
+_STRUCTURE_ENDPOINT = "https://api.humandelta.ai/v1/structure"
+
+_WIND_INSTRUCTIONS = (
+    "Extract the following wind parameters from the text. "
+    "Return only values that are explicitly stated or can be directly inferred. "
+    "wind_speed_ms: wind speed in metres per second (convert from knots if needed: 1 kt = 0.514 m/s). "
+    "wind_dir_deg: meteorological FROM-direction in degrees clockwise from North (0-360). "
+    "wind_drift_factor: fraction of wind speed applied as leeway to floating debris (0.02-0.04 typical). "
+    "confidence_score: your confidence in the extraction (0-1)."
+)
+
+_SAFE_FALLBACK: dict[str, float] = {
+    "wind_speed_ms": 0.0,
+    "wind_dir_deg": 0.0,
+    "wind_drift_factor": 0.0,
+    "confidence_score": 0.0,
+}
+
+
+class WindDataSchema(BaseModel):
+    wind_speed_ms: float = Field(..., ge=0, description="Wind speed in m/s")
+    wind_dir_deg: float = Field(..., ge=0, le=360, description="FROM-direction, degrees CW from North")
+    wind_drift_factor: float = Field(default=0.03, ge=0, le=0.1, description="Leeway fraction of wind speed")
+    confidence_score: float = Field(..., ge=0, le=1, description="Extraction confidence 0-1")
+
+
+class HumanDeltaClient:
+    """Thin async-capable client wrapping the Human Delta structuring API."""
+
+    def __init__(self) -> None:
+        api_key = os.getenv("HUMANDELTA_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "HUMANDELTA_API_KEY is not set. "
+                "Add it to your .env file or export it as an environment variable."
+            )
+        self._headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def structure_wind_data(self, unstructured_text: str) -> dict[str, Any]:
+        """Call Human Delta to extract wind parameters from free-text weather notes.
+
+        Returns a dict matching WindDataSchema fields, or a zero-valued fallback
+        if the request fails or the response fails validation.
+        """
+        payload = {
+            "text": unstructured_text,
+            "instructions": _WIND_INSTRUCTIONS,
+            "output_schema": WindDataSchema.model_json_schema(),
+        }
+
+        try:
+            with httpx.Client(timeout=15.0) as client:
+                response = client.post(
+                    _STRUCTURE_ENDPOINT,
+                    headers=self._headers,
+                    json=payload,
+                )
+                response.raise_for_status()
+                raw: dict[str, Any] = response.json()
+        except httpx.HTTPError as exc:
+            print(f"[wind_enrichment] HTTP error contacting Human Delta API: {exc}")
+            return dict(_SAFE_FALLBACK)
+
+        try:
+            validated = WindDataSchema.model_validate(raw)
+        except ValidationError as exc:
+            print(f"[wind_enrichment] Response failed schema validation: {exc}")
+            return dict(_SAFE_FALLBACK)
+
+        return validated.model_dump()


### PR DESCRIPTION
Introduces HumanDeltaClient (src/forecast/wind_enrichment.py) which POSTs unstructured weather/wind text to the Human Delta structuring API and validates the response against a WindDataSchema Pydantic model.  If the returned confidence_score exceeds 0.70, main() in drift.py overrides --wind-speed, --wind-dir, and --wind-drift-factor with the AI-extracted values.

API key is loaded exclusively from HUMANDELTA_API_KEY env var; a missing key raises ValueError immediately (Zero Trust, no hardcoded secrets).  Connection and validation failures return a zero-valued safe fallback so the drift run continues unaffected.

Also adds httpx>=0.27.0 to requirements.txt (pydantic and python-dotenv were already present).